### PR TITLE
カメラと地面の初期設定を変更

### DIFF
--- a/FollowCamera.cpp
+++ b/FollowCamera.cpp
@@ -2,20 +2,36 @@
 
 void FollowCamera::Initialize()
 {
-	offset_ = { 0.0f, 2.0f, -30.0f };
-
-	BaseCamera::Initialize();
+    // カメラの初期オフセット設定
+    offset_ = { 0.0f, 3.0f, -30.0f };
+    
+    // 基底クラスの初期化
+    BaseCamera::Initialize();
+    
+    // 初期位置を設定
+    if (target_) {
+        currentPosition_ = target_->transform.translate + offset_;
+        viewProjection_->transform.translate = currentPosition_;
+    }
+	//軽く傾ける
+	viewProjection_->transform.rotate = { 0.1f, 0.0f, 0.0f };
 }
 
 void FollowCamera::Update()
 {
-	if (target_ == nullptr)
-	{
-		assert(0);
-	}
+    if (target_ == nullptr)
+    {
+        assert(0);
+    }
 
-	viewProjection_->transform.translate = target_->transform.translate + offset_;
+    // ターゲット位置を取得
+    Vector3 targetPosition = target_->transform.translate + offset_;
+    
+    // 現在位置と目標位置の間を補間
+    currentPosition_ = Lerp(currentPosition_, targetPosition, easingFactor_);
+    
+    // カメラ位置を更新
+    viewProjection_->transform.translate = currentPosition_;
 
-
-	BaseCamera::Update();
+    BaseCamera::Update();
 }

--- a/FollowCamera.h
+++ b/FollowCamera.h
@@ -7,18 +7,24 @@ class FollowCamera : public BaseCamera
 {
 public:
 
-	// ������
+	// 初期化
 	void Initialize();
-
-	// �X�V����
+	// 更新
 	void Update();
 
 	void SetTarget(WorldTransform* target) { target_ = target; }
 
 private:
-
+	//========================================
+	// ターゲット
 	WorldTransform* target_ = nullptr;
-
+	//========================================
+	// オフセット
 	Vector3 offset_ = {};
+	//========================================
+	// 現在のカメラ位置
+	Vector3 currentPosition_ = {};
+	// イージング係数
+	float easingFactor_ = 0.85f;
 };
 

--- a/application/object/Ground.cpp
+++ b/application/object/Ground.cpp
@@ -10,7 +10,7 @@ void Ground::Initialize() {
 	worldTransform_ = std::make_unique<WorldTransform>();
 	worldTransform_->Initialize();
 	worldTransform_->transform.scale = { 1.0f,1.0f,1.0f };
-	worldTransform_->transform.rotate = { -0.02f,0.0f,0.0f };
+	worldTransform_->transform.rotate = { 0.0f,0.0f,0.0f };
 }
 
 void Ground::Update() {

--- a/application/object/Player.h
+++ b/application/object/Player.h
@@ -145,7 +145,7 @@ private:
 	float jumpVelocity_ = 0.2f; // 上昇速度
 	float fallSpeed_ = 0.0f;  	// 下降速度
 	float gravity_ = 0.16f;  	// 下降加速度
-	float initialY_ = 0.0f;  	// 初期Y座標
+	float initialY_ = 1.0f;  	// 初期Y座標
 	float floatBoost_ = 0.2f; 	// 離した瞬間の追加上昇量
 	float boostVelocity_ = 0.0f;// 追加上昇速度
 	float boostDecay_ = 0.02f;  // 追加上昇の減衰量


### PR DESCRIPTION
FollowCamera.cpp において、カメラの初期オフセットが {0.0f, 2.0f, -30.0f} から {0.0f, 3.0f, -30.0f} に変更されました。また、基底クラスの初期化後に、ターゲットが存在する場合の初期位置設定とカメラの軽い傾きが追加されました。Update メソッドでは、ターゲット位置の取得、現在位置と目標位置の補間、カメラ位置の更新が追加されました。

FollowCamera.h において、コメントが日本語に変更され、ターゲット、オフセット、現在のカメラ位置、イージング係数のメンバ変数が追加されました。

Ground.cpp において、Initialize メソッドで地面の回転が { -0.02f, 0.0f, 0.0f } から { 0.0f, 0.0f, 0.0f } に変更されました。

Player.h において、initialY_ の初期値が 0.0f から 1.0f に変更されました。